### PR TITLE
fix resources/tags route

### DIFF
--- a/src/cybershuttle_mcp_server.py
+++ b/src/cybershuttle_mcp_server.py
@@ -130,6 +130,12 @@ async def make_authenticated_request(method: str, endpoint: str, **kwargs) -> Di
 
 # === RESOURCE CONTROLLER ENDPOINTS ===
 
+@app.get("/resources/tags")
+async def get_all_tags():
+    """Get all available tags from the catalog."""
+    result = await make_authenticated_request("GET", "/api/v1/rf/resources/public/tags/all")
+    return result
+
 @app.get("/resources", response_model=List[ResourceResponse])
 async def list_resources(
     resource_type: Optional[str] = None,
@@ -207,12 +213,6 @@ async def get_resource(resource_id: str):
 async def create_dataset(data: Dict[str, Any]):
     """Create a new dataset resource."""
     result = await make_authenticated_request("POST", "/api/v1/rf/resources/dataset", json=data)
-    return result
-
-@app.get("/resources/tags")
-async def get_all_tags():
-    """Get all available tags from the catalog."""
-    result = await make_authenticated_request("GET", "/api/v1/rf/resources/public/tags/all")
     return result
 
 @app.post("/resources/notebook")
@@ -468,7 +468,7 @@ async def list_tools():
         ToolInfo(
             name="get_all_tags",
             description="Get all available tags from the catalog for filtering and organization",
-            endpoint="/resources/tags/all",
+            endpoint="/resources/tags",
             method="GET",
             parameters={},
             response_schema={"type": "array", "items": {"type": "string"}}


### PR DESCRIPTION
the resources/tags route is triggering the @app.get("/resources", response_model=List[ResourceResponse]), so i moved it above 

also fixed the ToolInfo endpoint line to /resources/tags instead of /resources/tags/all